### PR TITLE
Setting working flag in workAsync/workSync instead of pushAsync/pushSync

### DIFF
--- a/index.js
+++ b/index.js
@@ -22,6 +22,7 @@ function qlib(myWorkFunction) {
 	this.workSync = function() {
 		var item = queue[0];
 		if (item) {
+			this.working = true
 			queue.shift();
 			var element = item.el;
 			var fn = item.fn || myWorkFunction;
@@ -32,6 +33,7 @@ function qlib(myWorkFunction) {
     this.workAsync = function() {
 		var item = queue[0];
 		if (item) {
+			this.working = true;
 			queue.shift();
 			var element = item.el;
 			var fn = item.fn || myWorkFunction;
@@ -41,7 +43,6 @@ function qlib(myWorkFunction) {
 	this.pushSync = function(el,fn) {
 		queue.push({el:el,fn:fn,type:'sync'});
 		if ((queue.length > 0) && (this.working == false)) {
-			this.working = true;
 			this.workSync();
         }
 		return this;
@@ -49,7 +50,6 @@ function qlib(myWorkFunction) {
 	this.pushAsync = function(el,fn) {
 		queue.push({el:el,fn:fn,type:'async'});
 		if ((queue.length > 0) && (this.working == false)) {
-			this.working = true;
 			this.workAsync();
 		} else {
             console.log(this.working);


### PR DESCRIPTION
With the following steps:
- pushAsync two tasks A and B that lasts 1 second
- 1500ms after, pushAsync another one task C - this task would start immediately because the working flag was not set to true when task B started
